### PR TITLE
ActionPack 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ gemfile:
   - Gemfile.rails3
   - Gemfile.rails41
   - Gemfile.rails42
+  - Gemfile.rails50

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ gemfile:
   - Gemfile.rails41
   - Gemfile.rails42
   - Gemfile.rails50
+matrix:
+  allow_failures:
+    - gemfile: Gemfile.rails50
+      rvm: 2.1

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in hestia.gemspec
+gemspec
+
+gem "actionpack", "~> 5.0"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ We currently support (& test against):
 * Rails 3.2
 * Rails 4.1
 * Rails 4.2
+* Rails 5.0
 
 Pull requests always welcome to support other versions!
 
@@ -61,7 +62,7 @@ You should already have `Rails.application.config.secret_token` set to a value (
 
 *You can also set `config.deprecated_secret_token` to an array of strings to allow incoming cookies to be valid when signed with any of the secrets.*
 
-### Rails 4.1, 4.2
+### Rails 4.1, 4.2, 5.0
 
 Following the instructions for Rails 3.2 should work, but make sure you haven't set `config.secret_key_base` to a value otherwise Rails will take over and upgrade your cookies from signed to encrypted ones.
 

--- a/hestia.gemspec
+++ b/hestia.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_runtime_dependency "rack"
-  spec.add_runtime_dependency "actionpack", ">= 3.2.21", "< 5.0.0"
+  spec.add_runtime_dependency "actionpack", ">= 3.2.21", "< 5.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/hestia.rb
+++ b/lib/hestia.rb
@@ -2,4 +2,10 @@ module Hestia
   autoload :MessageMultiVerifier, "hestia/message_multi_verifier"
   autoload :SignedCookieJarExtension, "hestia/signed_cookie_jar_extension"
   autoload :VERSION, "hestia/version"
+
+  def self.check_secret_key_base
+    if Rails.application.config.respond_to?(:secret_key_base) && Rails.application.config.secret_key_base
+      fail "Having `config.secret_token' and `config.secret_key_base' defined is not allowed in Hestia. Please refer to Hestia's Readme for more information."
+    end
+  end
 end

--- a/lib/hestia/message_multi_verifier.rb
+++ b/lib/hestia/message_multi_verifier.rb
@@ -1,4 +1,5 @@
 require "active_support/message_verifier"
+require "active_support/message_encryptor"
 
 module Hestia
   class MessageMultiVerifier

--- a/lib/hestia/message_multi_verifier.rb
+++ b/lib/hestia/message_multi_verifier.rb
@@ -41,6 +41,10 @@ module Hestia
     # Returns deserialized value
     # Raises ActiveSupport::MessageVerifier::InvalidSignature
     def verify(signed_message)
+      verified(signed_message)
+    end
+
+    def verified(signed_message)
       errored_verifier_count = 0
 
       # Make sure we check *all* verifiers, every time we're called, to prevent timing attacks.

--- a/lib/hestia/railtie.rb
+++ b/lib/hestia/railtie.rb
@@ -10,7 +10,7 @@ module Hestia
       extension = case ActionPack::VERSION::MAJOR
       when 3
         Hestia::SignedCookieJarExtension::ActionPack3
-      when 4
+      else
         if Rails.application.config.respond_to?(:secret_key_base) && Rails.application.config.secret_key_base
           fail "Having `config.secret_token' and `config.secret_key_base' defined is not allowed in Hestia. Please refer to Hestia's Readme for more information."
         end

--- a/lib/hestia/railtie.rb
+++ b/lib/hestia/railtie.rb
@@ -16,8 +16,6 @@ module Hestia
         end
 
         Hestia::SignedCookieJarExtension::ActionPack4
-      else
-        raise "Unsupported version of action_pack: #{ActionPack::VERSION::STRING.inspect}"
       end
 
       ActionDispatch::Cookies::SignedCookieJar.prepend(extension)

--- a/lib/hestia/railtie.rb
+++ b/lib/hestia/railtie.rb
@@ -10,12 +10,12 @@ module Hestia
       extension = case ActionPack::VERSION::MAJOR
       when 3
         Hestia::SignedCookieJarExtension::ActionPack3
-      else
-        if Rails.application.config.respond_to?(:secret_key_base) && Rails.application.config.secret_key_base
-          fail "Having `config.secret_token' and `config.secret_key_base' defined is not allowed in Hestia. Please refer to Hestia's Readme for more information."
-        end
-
+      when 4
+        Hestia.check_secret_key_base
         Hestia::SignedCookieJarExtension::ActionPack4
+      when 5
+        Hestia.check_secret_key_base
+        Hestia::SignedCookieJarExtension::ActionPack5
       end
 
       ActionDispatch::Cookies::SignedCookieJar.prepend(extension)

--- a/lib/hestia/signed_cookie_jar_extension.rb
+++ b/lib/hestia/signed_cookie_jar_extension.rb
@@ -2,5 +2,6 @@ module Hestia
   module SignedCookieJarExtension
     autoload :ActionPack3, "hestia/signed_cookie_jar_extension/action_pack_3"
     autoload :ActionPack4, "hestia/signed_cookie_jar_extension/action_pack_4"
+    autoload :ActionPack5, "hestia/signed_cookie_jar_extension/action_pack_5"
   end
 end

--- a/lib/hestia/signed_cookie_jar_extension/action_pack_5.rb
+++ b/lib/hestia/signed_cookie_jar_extension/action_pack_5.rb
@@ -1,0 +1,41 @@
+require 'active_support/version'
+
+module Hestia
+  module SignedCookieJarExtension
+    module ActionPack5
+      # Public: overridden #initialize method
+      #
+      # In rails, `secrets' will be given the value of `Rails.application.config.secret_token'. That's the current secret token.
+      # This also reads from `Rails.application.config.deprecated_secret_token` for deprecated token(s) to use. It can be undefined, a
+      # string or an array of string.
+      #
+      # parent_jar [ActionDispatch::Cookies] the parent jar creating this signed cookie jar
+      # secret [String] current secret token. Used to verify & sign cookies.
+      #
+      def initialize(parent_jar)
+        super
+
+        # Find the deprecated secrets, if there are any
+        deprecated_secrets = if Rails.application.config.respond_to?(:deprecated_secret_token)
+          # This could be a single string!
+          Array(Rails.application.config.deprecated_secret_token)
+        else
+          []
+        end
+
+        # Grab the `config.secret_token` value from its generator
+        active_secret = key_generator.generate_key(request.signed_cookie_salt)
+
+        # Take the deprecated secrets through the same generator code
+        deprecated_secrets.map do |secret|
+          ActiveSupport::LegacyKeyGenerator.new(secret).generate_key(request.signed_cookie_salt)
+        end
+
+        serializer = ActiveSupport.version.to_s > "4.1" ? ActiveSupport::MessageEncryptor::NullSerializer : ActionDispatch::Cookies::NullSerializer
+
+        # Finally, override @verifier with our own multi verifier containing all the secrets
+        @verifier = Hestia::MessageMultiVerifier.new(current_secret: active_secret, deprecated_secrets: deprecated_secrets, options: {serializer: serializer})
+      end
+    end
+  end
+end

--- a/spec/hestia/message_multi_verifier_spec.rb
+++ b/spec/hestia/message_multi_verifier_spec.rb
@@ -1,4 +1,5 @@
 require_relative "../spec_helper"
+require "action_pack/version"
 
 module Hestia
   describe MessageMultiVerifier do
@@ -91,11 +92,13 @@ module Hestia
         multi_verifier.verify(legacy_cookie).must_equal "cookie dough"
       end
 
-      it "verifies a message of `nil' successfully" do
-        nil_cookie = singular_verifier.generate(nil)
+      if ActionPack::VERSION::MAJOR < 5
+        it "verifies a message of `nil' successfully" do
+          nil_cookie = singular_verifier.generate(nil)
 
-        singular_verifier.verify(nil_cookie).must_equal(nil)
-        multi_verifier.verify(nil_cookie).must_equal(nil)
+          singular_verifier.verify(nil_cookie).must_equal(nil)
+          multi_verifier.verify(nil_cookie).must_equal(nil)
+        end
       end
 
       it "verifies successfully when using custom digest" do

--- a/spec/hestia/signed_cookie_jar_extension/action_pack_5_spec.rb
+++ b/spec/hestia/signed_cookie_jar_extension/action_pack_5_spec.rb
@@ -1,0 +1,103 @@
+require_relative "../../spec_helper"
+require_relative "../../support/fake_rails"
+require_relative "../../support/fake_cookie_jar"
+require "action_dispatch/middleware/cookies"
+
+# Call our railtie block to setup the initializers array
+require "hestia/railtie"
+
+module Hestia
+  if ActionPack::VERSION::MAJOR == 5
+    describe SignedCookieJarExtension::ActionPack5 do
+      before do
+        Rails.clean
+        load_railtie
+      end
+
+      it "is prepended into signed cookie jar ancestors" do
+        ActionDispatch::Cookies::SignedCookieJar.ancestors.first.must_equal SignedCookieJarExtension::ActionPack5
+      end
+
+      it "defines initialize" do
+        # #initialize doesn't show up in {instance_,}methods({false,true}) for some reason, so do this instead
+        # This will throw a NameError if we don't define it
+        SignedCookieJarExtension::ActionPack5.instance_method(:initialize)
+      end
+
+      describe "signed cookie jar instance with no deprecated token" do
+        before do
+          @secret = "a" * 30
+          @parent_jar = FakeCookieJar.new(@secret)
+          @jar = ActionDispatch::Cookies::SignedCookieJar.new(@parent_jar)
+        end
+
+        it "calls the original initialize method" do
+          @jar.instance_variable_get(:@parent_jar).must_equal @parent_jar
+        end
+
+        describe "validator" do
+          before do
+            @verifier = @jar.instance_variable_get(:@verifier)
+          end
+          it "is a multi message validator" do
+            @verifier.must_be_kind_of(MessageMultiVerifier)
+          end
+
+          it "has the correct secrets stored" do
+            secrets = @verifier.instance_variable_get(:@verifiers).map { |x| x.instance_variable_get(:@secret) }
+            secrets.must_equal [@secret]
+          end
+        end
+      end
+
+      describe "signed cookie jar instance with deprecated token" do
+        before do
+          @secret = "a" * 30
+          @parent_jar = FakeCookieJar.new(@secret)
+          @deprecated_secret = "b" * 30
+          Rails.application.config.deprecated_secret_token = @deprecated_secret
+          @jar = ActionDispatch::Cookies::SignedCookieJar.new(@parent_jar)
+        end
+
+        it "calls the original initialize method" do
+          @jar.instance_variable_get(:@parent_jar).must_equal @parent_jar
+        end
+
+        describe "validator" do
+          before do
+            @verifier = @jar.instance_variable_get(:@verifier)
+          end
+          it "is a multi message validator" do
+            @verifier.must_be_kind_of(MessageMultiVerifier)
+          end
+
+          it "has the correct secrets stored" do
+            secrets = @verifier.instance_variable_get(:@verifiers).map { |x| x.instance_variable_get(:@secret) }
+            secrets.must_equal [@secret, @deprecated_secret]
+          end
+        end
+      end
+
+      describe "with secret_key_base defined in config" do
+        it "blows up" do
+          Rails.clean
+
+          Rails.application.config.secret_token = "a" * 64
+          Rails.application.config.secret_key_base = "b" * 64
+
+          -> { load_railtie }.must_raise(RuntimeError)
+        end
+      end
+
+      private
+
+      def load_railtie
+        if (init = Rails::Railtie.initializers.first)
+          _, _, block = init
+          block.call
+        end
+      end
+
+    end
+  end
+end

--- a/spec/support/fake_cookie_jar.rb
+++ b/spec/support/fake_cookie_jar.rb
@@ -1,0 +1,11 @@
+class FakeCookieJar
+  attr_reader :request, :key_generator, :signed_cookie_salt, :cookies_digest
+
+  def initialize(secret)
+    @secret = secret
+    @request = self
+    @signed_cookie_salt = nil
+    @cookies_digest = nil
+    @key_generator = ActiveSupport::LegacyKeyGenerator.new(@secret)
+  end
+end


### PR DESCRIPTION
This PR adds support for Rails 5.0. 

`config.secret_key_base` should still be nil for this to work. 